### PR TITLE
Fix QA in CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
       run: docker build ./ -t velodrome/api
 
     - name: Runs code QA and tests
-      run: docker run --rm --env-file=env.example -v $(pwd):/app -w /app -t velodrome/api sh -c 'pip install coverage flake8 && flake8 && coverage run --source=app setup.py test && coverage report'
+      run: docker run --rm --env-file=${{ github.workspace }}/env.example -v ${{ github.workspace }}:/app -w /app -t velodrome/api sh -c 'pip install coverage flake8 && flake8 && coverage run --source=app setup.py test && coverage report'

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ env
 .env
 node_modules
 .env.example.copy
+.idea/

--- a/app/configuration/__init__.py
+++ b/app/configuration/__init__.py
@@ -7,7 +7,7 @@ from versiontools import Version
 
 from app import __version__
 from app.pairs import Token
-from app.settings import CACHE, DEFAULT_TOKEN_ADDRESS, STABLE_TOKEN_ADDRESS,\
+from app.settings import CACHE, DEFAULT_TOKEN_ADDRESS, STABLE_TOKEN_ADDRESS, \
     ROUTE_TOKEN_ADDRESSES, LOGGER
 
 

--- a/app/gauges/model.py
+++ b/app/gauges/model.py
@@ -10,13 +10,15 @@ from web3.constants import ADDRESS_ZERO
 
 from app.settings import (
     LOGGER, CACHE, VOTER_ADDRESS,
-    DEFAULT_TOKEN_ADDRESS, WRAPPED_BRIBE_FACTORY_ADDRESS, VE_ADDRESS, PRIVATE_KEY, WRAPPED_BRIBE_ABI
+    DEFAULT_TOKEN_ADDRESS, WRAPPED_BRIBE_FACTORY_ADDRESS,
+    VE_ADDRESS, PRIVATE_KEY, WRAPPED_BRIBE_ABI
 )
 from app.assets import Token
 
-# set up private key to web3 
+# set up private key to web3
 account: LocalAccount = Account.from_key(PRIVATE_KEY)
 w3.middleware_onion.add(construct_sign_and_send_raw_middleware(account))
+
 
 class Gauge(Model):
     """Gauge model."""
@@ -108,8 +110,8 @@ class Gauge(Model):
             )()
 
         if data.get('wrapped_bribe_address') in (ADDRESS_ZERO, ''):
-                cls.create_wrapped_bribe(data['bribe_address'])
-                data['wrapped_bribe_address'] = Call(
+            cls.create_wrapped_bribe(data['bribe_address'])
+            data['wrapped_bribe_address'] = Call(
                 WRAPPED_BRIBE_FACTORY_ADDRESS,
                 ['oldBribeToNew(address)(address)', data['bribe_address']]
             )()
@@ -130,19 +132,26 @@ class Gauge(Model):
 
     @classmethod
     def create_wrapped_bribe(cls, bribe_address):
-        wrapped_bribe_factory_contract = w3.eth.contract(address=WRAPPED_BRIBE_FACTORY_ADDRESS, abi=WRAPPED_BRIBE_ABI)
-        nonce = w3.eth.get_transaction_count(account.address)  
-        
-        checksum_address = w3.toChecksumAddress(bribe_address)
-        create_bribe_txn = wrapped_bribe_factory_contract.functions.createBribe(checksum_address).buildTransaction({
-            'chainId': 42161,
-            'maxFeePerGas': w3.toWei('0.1', 'gwei'),
-            'maxPriorityFeePerGas': w3.toWei('0.1', 'gwei'),
-            'nonce': nonce,
-        })
+        wrapped_bribe_factory_contract = w3.eth.contract(
+            address=WRAPPED_BRIBE_FACTORY_ADDRESS, abi=WRAPPED_BRIBE_ABI
+        )
+        nonce = w3.eth.get_transaction_count(account.address)
 
-        signed_txn = w3.eth.account.sign_transaction(create_bribe_txn, private_key=PRIVATE_KEY)
-        w3.eth.send_raw_transaction(signed_txn.rawTransaction)  
+        checksum_address = w3.toChecksumAddress(bribe_address)
+        create_bribe_txn = wrapped_bribe_factory_contract.\
+            functions.createBribe(
+                checksum_address
+            ).buildTransaction({
+                'chainId': 42161,
+                'maxFeePerGas': w3.toWei('0.1', 'gwei'),
+                'maxPriorityFeePerGas': w3.toWei('0.1', 'gwei'),
+                'nonce': nonce,
+            })
+
+        signed_txn = w3.eth.account.sign_transaction(
+            create_bribe_txn, private_key=PRIVATE_KEY
+        )
+        w3.eth.send_raw_transaction(signed_txn.rawTransaction)
         sent = w3.toHex(w3.keccak(signed_txn.rawTransaction))
         LOGGER.info('Created tx: ', sent)
 

--- a/app/settings/__init__.py
+++ b/app/settings/__init__.py
@@ -57,7 +57,83 @@ ROUTER_ADDRESS = os.getenv('ROUTER_ADDRESS')
 VE_ADDRESS = os.getenv('VE_ADDRESS')
 REWARDS_DIST_ADDRESS = os.getenv('REWARDS_DIST_ADDRESS')
 WRAPPED_BRIBE_FACTORY_ADDRESS = os.getenv('WRAPPED_BRIBE_FACTORY_ADDRESS')
-WRAPPED_BRIBE_ABI = json.loads('[{"inputs":[{"internalType":"address","name":"_voter","type":"address"}],"stateMutability":"nonpayable","type":"constructor"},{"inputs":[{"internalType":"address","name":"existing_bribe","type":"address"}],"name":"createBribe","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"last_bribe","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"}],"name":"oldBribeToNew","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"voter","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"}]')
+WRAPPED_BRIBE_ABI = json.loads("""[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_voter",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "existing_bribe",
+        "type": "address"
+      }
+    ],
+    "name": "createBribe",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "last_bribe",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "oldBribeToNew",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "voter",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]""")
 
 # Seconds to wait before running the chain syncup. `0` disables it!
 SYNC_WAIT_SECONDS = int(os.getenv('SYNC_WAIT_SECONDS', 0))

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,7 @@
 # Velodrome Finance HTTP API 🚲💨🕸️
 
 Velodrome Finance HTTP API is used by our app to fetch tokens and liquidity
-pool pairs.
-
+pool pairs. \
 Please make sure you have [Docker](https://docs.docker.com/install/) first.
 
 To build the image, run:


### PR DESCRIPTION
This PR modifies the command that runs the QA check after docker image is built to correctly use the env.example file in the project root directory.
Additionally all errors pointed out by the check have been fixed (all of them have been typos).

The QA check still needs the PRIVATE_KEY environment variable to complete successfully, but I assume that in your case it was set in the GitHub repo settings.